### PR TITLE
Chushogi: Fix bug with non-lion double movers capturing lion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for shogiops
 
+## v0.16.2
+
+- Fixed `chushogi` bug where non-Lion double movers making a mid-step Lion capture was not preventing Lion counterstrike.
+
 ## v0.16.1
 
 - Fixed `annanshogi` move generation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shogiops",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "shogiops",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@badrap/result": "^0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shogiops",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Shogi rules and operations",
   "keywords": [
     "shogi",

--- a/src/variant/position.ts
+++ b/src/variant/position.ts
@@ -298,13 +298,19 @@ export abstract class Position {
         piece.role = promote(this.rules)(role) || role;
 
       const capture = this.board.set(md.to, piece),
-        secondCapture = defined(md.midStep) ? this.board.take(md.midStep) : undefined;
+        midCapture = defined(md.midStep) ? this.board.take(md.midStep) : undefined;
+
+      // process midCapture (if exists) before final destination capture
+      if (defined(midCapture)) {
+        if (!lionRoles.includes(role) && midCapture.color === this.turn && lionRoles.includes(midCapture.role))
+          this.lastLionCapture = md.midStep;
+        this.storeCapture(midCapture);
+      }
       if (capture) {
         if (!lionRoles.includes(role) && capture.color === this.turn && lionRoles.includes(capture.role))
           this.lastLionCapture = md.to;
         this.storeCapture(capture);
       }
-      if (defined(secondCapture)) this.storeCapture(secondCapture);
     }
   }
 }


### PR DESCRIPTION
Addressing issue: https://github.com/WandererXII/lishogi/issues/830

It was discovered that when a non-Lion double mover captures a Lion on the mid step and then moves to another square (igui or hit and run), the last lion capture square used for counterstrike protection rules was not being set. Several highly skilled/professional players confirmed that this is a bug, and that the eagle/falcon should set this square despite having made the capture with a "Lion move". 

My changes here allow for the Lion capture square to be set off of a mid step capture, not just a final square capture. 

Specifically: 
- Rename `secondCapture` to `midCapture`, which is more correct
- Process the `midCapture` first, since it happens before the `capture` at the final square
- Allow setting the last lion captured square from the mid step and the final step
- If a Lion was captured on both squares, due to the adjusted ordering the final square will be the last lion capture

Cheers, and please let me know if anything with my PR needs adjustments (such as changelog/versioning things).